### PR TITLE
Type and size directives for generated ASM

### DIFF
--- a/ppcdis/disassembler.py
+++ b/ppcdis/disassembler.py
@@ -457,7 +457,7 @@ class Disassembler:
                 sym_type = "@function" if sec.type == SectionType.TEXT else "@object"
                 sym_type_dir = f"\n.type {name}, {sym_type}"
                 
-                suffix = f"\n.size {name}, .-{name}\n"
+                suffix = f"\n.size {name}, . - {name}\n"
                 
             prefix = f"\n.global {name}{sym_type_dir}\n{align}{name}:\n"
         

--- a/ppcdis/disassembler.py
+++ b/ppcdis/disassembler.py
@@ -450,12 +450,21 @@ class Disassembler:
         if inline:
             prefix = "nofralloc\n" if sec.type == SectionType.TEXT else ""
         else:
-            prefix = f"\n.global {name}\n{align}{name}:\n"
-
+            if sec.name == ".ctors" or sec.name == ".dtors":
+                sym_type_dir = ""
+                suffix = ""
+            else:
+                sym_type = "@function" if sec.type == SectionType.TEXT else "@object"
+                sym_type_dir = f"\n.type {name}, {sym_type}"
+                
+                suffix = f"\n.size {name}, .-{name}\n"
+                
+            prefix = f"\n.global {name}{sym_type_dir}\n{align}{name}:\n"
+        
         if sec.type == SectionType.TEXT:
-            return prefix + self._disasm_function(addr, inline, hashable, referenced)
+            return prefix + self._disasm_function(addr, inline, hashable, referenced) + suffix
         else:
-            return prefix + self._disasm_data(sec, addr)
+            return prefix + self._disasm_data(sec, addr) + suffix
 
     def _disasm_range(self, sec: BinarySection, start: int, end: int, inline=False,
                       hashable=False, referenced=None) -> str:

--- a/ppcdis/disassembler.py
+++ b/ppcdis/disassembler.py
@@ -447,12 +447,14 @@ class Disassembler:
         # Add .global and symbol name if required
         name = self._sym.get_name(addr, hashable, True)
         assert name is not None and self._sym.is_global(addr)
+        
+        suffix = ""
+        
         if inline:
             prefix = "nofralloc\n" if sec.type == SectionType.TEXT else ""
         else:
             if sec.name == ".ctors" or sec.name == ".dtors":
                 sym_type_dir = ""
-                suffix = ""
             else:
                 sym_type = "@function" if sec.type == SectionType.TEXT else "@object"
                 sym_type_dir = f"\n.type {name}, {sym_type}"


### PR DESCRIPTION
This PR adds the `.type` and `.size` directives to symbols output by the disassembler. The `.ctors` and `.dtors` segments are exempt from this, as adding the directives to those segments caused compiler errors (`Static initializers must be called before 'main'` and `Destructors must be called in 'exit'`).