### PR TITLE
Support .L for local labels

### DIFF
--- a/ppcdis/disassembler.py
+++ b/ppcdis/disassembler.py
@@ -112,6 +112,8 @@ class DisasmLine:
                         prefix.append(f".global {name}")
                         prefix.append(f"{name}:")
             else:
+                # Use the inline version of the name for non-global addresses if inline asm
+                name = sym.get_name_inline(self.instr.address, hashable, True) if inline else name
                 prefix.append(f"{name}:")
 
         # Add jumptable label if required
@@ -191,7 +193,7 @@ class Disassembler:
         dest = instr.operands[-1].imm
         
         # Get symbol name
-        name = self._sym.get_name(dest, hashable)
+        name = self._sym.get_name_inline(dest, hashable) if inline and not self._sym.is_global(dest) else self._sym.get_name(dest, hashable)
 
         # Use hardcoded address if needed
         # TODO: make shiftable somehow

--- a/ppcdis/symbols.py
+++ b/ppcdis/symbols.py
@@ -233,6 +233,24 @@ class SymbolGetter:
                 return sym.name
         else:
             return None
+        
+    def get_name_inline(self, addr: int, hash_mode=False, miss_ok=False) -> str:
+        """Checks the name of the symbol at an address
+        for inline asm functions
+        
+        Asserts the symbol exists unless miss_ok"""
+
+        assert miss_ok or addr in self._sym, f"Address {addr:x} missed in analysis"
+
+        sym = self._sym.get(addr)
+
+        if sym is not None:
+            if hash_mode:
+                return self.get_hash_name(addr)
+            else:
+                return f"lbl_{addr:x}"
+        else:
+            return None
 
     def is_global(self, addr: int, miss_ok=False) -> bool:
         """Checks whether the symbol at an address is global


### PR DESCRIPTION
Adds the bare minimum to support `.L` local label syntax while still supporting valid inline assembly. Users should set the `label_prefix` setting in their configuration yaml files to `.L` to enable this.